### PR TITLE
Added support OS Maintainer profile update:

### DIFF
--- a/user_profile/templates/user_profile/profile_form.html
+++ b/user_profile/templates/user_profile/profile_form.html
@@ -291,6 +291,53 @@
         </div>
         {% endif %}
 
+        <!-- OS Maintainer profile Form  -->
+        {% if osm_form %}
+        <div class="divider">Open Source Maintainer Details</div>
+
+        <!-- GitHub Username -->
+        <div class="form-control">
+          <label class="label block" for="{{ osm_form.github_username.id_for_label }}">
+            <span class="label-text">GitHub Username</span>
+          </label>
+          <input
+            type="text"
+            name="{{ osm_form.github_username.html_name }}"
+            id="{{ osm_form.github_username.id_for_label }}"
+            value="{{ osm_form.github_username.value|default:'' }}"
+            class="input input-bordered w-full{% if osm_form.github_username.errors %} input-error{% endif %}"
+          />
+          {% if osm_form.github_username.errors %}
+          <label class="label">
+            <span class="label-text-alt text-error">
+              {{ osm_form.github_username.errors|join:", " }}
+            </span>
+          </label>
+          {% endif %}
+        </div>
+
+        <!-- About -->
+        <div class="form-control">
+          <label class="label block" for="{{ osm_form.about.id_for_label }}">
+            <span class="label-text">About</span>
+          </label>
+          <textarea
+            name="{{ osm_form.about.html_name }}"
+            id="{{ osm_form.about.id_for_label }}"
+            class="textarea textarea-bordered w-full{% if osm_form.about.errors %} textarea-error{% endif %}"
+            rows="4"
+          >{{ osm_form.about.value|default:'' }}</textarea>
+          {% if osm_form.about.errors %}
+          <label class="label">
+            <span class="label-text-alt text-error">
+              {{ osm_form.about.errors|join:", " }}
+            </span>
+          </label>
+          {% endif %}
+        </div>
+        {% endif %}
+
+
 
         <div class="form-control mt-6">
           <button class="btn btn-primary" type="submit">

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -10,6 +10,7 @@ from .forms import (
     ProfileUpdateForm,
     WomenInTechUpdateForm,
     MentorUpdateForm,
+    OS_MaintainerUpdateForm,
 )
 
 
@@ -52,6 +53,12 @@ def profile_update(request):
         else:
             mentor_form = None
 
+        osm_form = None
+        if hasattr(request.user, "os_maintainer_profile"):
+            osm_form = OS_MaintainerUpdateForm(
+                request.POST, request.FILES, instance=request.user.os_maintainer_profile
+            )
+
         if user_form.is_valid() and profile_form.is_valid():
             user_form.save()
             profile_form.save()
@@ -61,6 +68,9 @@ def profile_update(request):
 
             if mentor_form and mentor_form.is_valid():
                 mentor_form.save()
+
+            if osm_form and osm_form.is_valid():
+                osm_form.save()
 
             messages.success(request, "Your profile has been updated!")
             return redirect("profile_detail", username=request.user.username)
@@ -80,11 +90,19 @@ def profile_update(request):
         else:
             mentor_form = None
 
+        if hasattr(request.user, "os_maintainer_profile"):
+            osm_form = OS_MaintainerUpdateForm(
+                instance=request.user.os_maintainer_profile
+            )
+        else:
+            osm_form = None
+
     context = {
         "user_form": user_form,
         "profile_form": profile_form,
         "wit_form": wit_form,
         "mentor_form": mentor_form,
+        "osm_form": osm_form,
     }
     return render(request, "user_profile/profile_form.html", context)
 


### PR DESCRIPTION
profile/views.py:
- import `OS_MaintainerUpdateForm`.
- Includee logic to check if the user has an `os_maintainer_profile` and initialize the form accordingly.
- Added form validation and saving logic for the new OS Maintainer form.
- Passed the `osm_form` to the context so it can be rendered in the template.

user_profile/templates/user_profile/profile_form.html:
- Added a new section in the profile form UI for editing Open Source Maintainer details.
- Displayed inputs for GitHub Username and About fields for OS Maintainers.
- Wrapped the section with `{% if osm_form %}` to conditionally show it only when applicable.
- Included validation error messages for each new input, consistent with existing form error handling.