### PR TITLE
Switch navbar breakpoint from `lg` to `xl`.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -30,7 +30,7 @@
     <div class="navbar bg-base-200 shadow-md">
       <div class="navbar-start">
         <div class="dropdown">
-          <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
+          <div tabindex="0" role="button" class="btn btn-ghost xl:hidden">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" />
             </svg>
@@ -89,7 +89,7 @@
         </div>
         <a href="{% url 'home' %}" class="btn btn-ghost text-xs md:text-xl"><div class="logo"></div></a>
       </div>
-      <div class="navbar-center hidden lg:flex">
+      <div class="navbar-center hidden xl:flex">
         <ul class="menu menu-horizontal px-1">
           <li>
             <a href="{% url 'team' %}">


### PR DESCRIPTION
Now the hamburger menu activates earlier and prevents link overflow on mid-sized screens.