### PR TITLE
Warren/success sponsor pages

### DIFF
--- a/donations/templates/donations/success.html
+++ b/donations/templates/donations/success.html
@@ -164,7 +164,7 @@
                         <progress class="progress progress-primary w-full" value="{{ other_wit.sponsorship_percentage }}" max="100"></progress>
                     </div>
                     <div class="card-actions justify-end mt-4">
-                        <a href="{% url 'profile_detail' pk=other_wit.user.id %}" class="btn btn-retro btn-sm">View Profile</a>
+                        <a href="{% url 'profile_detail' username=other_wit.user.username %}" class="btn btn-retro btn-sm">View Profile</a>
                     </div>
                 </div>
             </div>

--- a/donations/urls.py
+++ b/donations/urls.py
@@ -16,7 +16,6 @@ urlpatterns = [
         views.create_sponsorship_session,
         name="create_sponsorship_session",
     ),
-    path("sponsorship/success/", views.sponsorship_success, name="sponsorship_success"),
     # women in tech
     path(
         "sponsorship/", views.WomenInTechListView.as_view(), name="women_in_tech_list"

--- a/donations/views.py
+++ b/donations/views.py
@@ -145,6 +145,7 @@ def success(request):
     """
     Handle successful payments
     """
+
     # Get the session ID from query parameters
     session_id = request.GET.get("session_id")
     if not session_id:
@@ -267,7 +268,7 @@ def create_sponsorship_session(request):
     data = json.loads(request.body)
     amount = int(float(data.get("amount", 10)) * 100)  # Convert to cents
     wit_id = data.get("wit_id")
-    success_url = request.build_absolute_uri("/donations/sponsorship/success/")
+    success_url = request.build_absolute_uri("/donations/success/")
     cancel_url = request.build_absolute_uri("/donations/cancel/")
 
     try:
@@ -300,30 +301,3 @@ def create_sponsorship_session(request):
         return JsonResponse({"id": checkout_session.id})
     except Exception as e:
         return JsonResponse({"error": str(e)}, status=400)
-
-
-def sponsorship_success(request):
-    session_id = request.GET.get("session_id")
-    if not session_id:
-        return render(
-            request, "donations/error.html", {"error_message": "No session ID provided"}
-        )
-
-    try:
-        session = stripe.checkout.Session.retrieve(session_id)
-        payment = handle_completed_checkout(session)
-
-        return render(
-            request,
-            "donations/sponsorship_success.html",
-            {
-                "payment": payment,
-                "save_info": request.session.get("save_info"),
-            },
-        )
-    except Exception as e:
-        return render(
-            request,
-            "donations/error.html",
-            {"error_message": f"Error retrieving payment: {str(e)}"},
-        )

--- a/user_profile/models.py
+++ b/user_profile/models.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.urls import reverse
 
+from donations.models import Payment
 from os_project.models import Project
 
 


### PR DESCRIPTION
Success view now solely handles logic for project successful payments and WIT successful payments.

-  **NameError: name 'Payment' is not defined**
      - Fixed an error  where payment was not being defined by importing payment model to the user_profile models.

- **Error retrieving payment: Reverse for 'profile_detail' with keyword arguments '{'pk': 1}' not found. 1 pattern(s) tried: ['profile/(?P<username>[^/]+)/\\Z']**
    - Fixed an error where I was trying to generate a URL using reverse("profile_detail", kwargs={"pk": 1}), but the URL pattern is expecting username, not pk. Fixed this in the HTML success page.

- Success page now displays donations for Women in tech similar to how projects donations are displayed 
![image_2025-04-05_235407167](https://github.com/user-attachments/assets/f215ae1a-345b-4ee1-86fc-6c7a846f828f)
